### PR TITLE
Untrusted Methods

### DIFF
--- a/src/zope/security/proxy.py
+++ b/src/zope/security/proxy.py
@@ -14,7 +14,9 @@
 """Helper functions for Proxies.
 """
 import functools
+from six import get_unbound_function, create_bound_method
 import sys
+import types
 
 from zope.proxy import PyProxyBase
 from zope.security._compat import PYPY
@@ -88,7 +90,10 @@ class ProxyPy(PyProxyBase):
                         '__lt__', '__le__', '__eq__', '__ne__', '__ge__',
                         '__gt__']:
             checker.check_getattr(wrapped, name)
-        return checker.proxy(super(ProxyPy, self).__getattribute__(name))
+        attr = super(ProxyPy, self).__getattribute__(name)
+        if isinstance(attr, types.MethodType):
+            attr = create_bound_method(get_unbound_function(attr), self)
+        return checker.proxy(attr)
 
     def __getattr__(self, name):
         wrapped = super(PyProxyBase, self).__getattribute__('_wrapped')


### PR DESCRIPTION
After one allows method via `allow` or `require`:

``` xml
<class class="ProtectedClass">
  <allow attributes="method" />
</class>
```

`self` is unprotected (unwrapped) inside `method`.

The approach allows passing proxy object inside method not to trust its code.

C implementation is missing, and is yet TBD.

We'd like to get initial feedback on the approach and other options to achieve the **Untrusted Methods** goal.
