### PR TITLE
Compatibility with zope.proxy 4.1.5 under PyPy.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changes
 4.0.2 (unreleased)
 ------------------
 
-- Compatibility with ``zope.proxy`` 4.1.5 under PyPy.
+- Fixed compatibility with ``zope.proxy`` 4.1.5 under PyPy.
+
+- Fixed the very first call to ``removeSecurityProxy`` returning
+  incorrect results if given a proxy under PyPy.
 
 4.0.1 (2014-03-19)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 4.0.2 (unreleased)
 ------------------
 
-- TBD
+- Compatibility with ``zope.proxy`` 4.1.5 under PyPy.
 
 4.0.1 (2014-03-19)
 ------------------

--- a/src/zope/security/proxy.py
+++ b/src/zope/security/proxy.py
@@ -315,7 +315,10 @@ for name in ['__iadd__',
 def getCheckerPy(proxy):
     return super(PyProxyBase, proxy).__getattribute__('_checker')
 
-_builtin_isinstance = __builtins__.isinstance
+if PYPY:
+    _builtin_isinstance = __builtins__.isinstance
+else:
+    _builtin_isinstance = __builtins__['isinstance']
 
 def getObjectPy(proxy):
     if not _builtin_isinstance(proxy, ProxyPy):

--- a/src/zope/security/proxy.py
+++ b/src/zope/security/proxy.py
@@ -315,9 +315,10 @@ for name in ['__iadd__',
 def getCheckerPy(proxy):
     return super(PyProxyBase, proxy).__getattribute__('_checker')
 
+_builtin_isinstance = __builtins__.isinstance
+
 def getObjectPy(proxy):
-    isinstance_func = builtin_isinstance or isinstance
-    if not isinstance_func(proxy, ProxyPy):
+    if not _builtin_isinstance(proxy, ProxyPy):
         return proxy
     return super(PyProxyBase, proxy).__getattribute__('_wrapped')
 
@@ -341,18 +342,11 @@ def getTestProxyItems(proxy):
     return sorted(checker.get_permissions.items())
 
 
-builtin_isinstance = None
 def isinstance(object, cls):
     """Test whether an object is an instance of a type.
 
-    This works even if the object is security proxied:
+    This works even if the object is security proxied.
     """
-    global builtin_isinstance
-    if builtin_isinstance is None:
-        if PYPY:
-            builtin_isinstance = getattr(__builtins__, 'isinstance')
-        else:
-            builtin_isinstance = __builtins__['isinstance']
     # The removeSecurityProxy call is OK here because it is *only*
     # being used for isinstance
-    return builtin_isinstance(removeSecurityProxy(object), cls)
+    return _builtin_isinstance(removeSecurityProxy(object), cls)


### PR DESCRIPTION
`zope.proxy` 4.1.5 made the pure-Python implementation match the C implementation with respect to handling descriptors/attributes of subclasses. It also explicitly prohibited pickling proxy instances, like the C implementation.

The C proxy found in `zope.security`, however, did not implement these behaviours. It allowed any proxy to be pickled and ignored descriptors in subclasses. Yet the Python implementation found here uses the Python code in `zope.proxy` as a base, resulting in breaking the following test.

```
======================================================================
ERROR: test_that_pickling_CheckerPublic_retains_identity (zope.security.tests.test_checker.TestCheckerPublic)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/zope.security/src/zope/security/tests/test_checker.py", line 1863, in test_that_pickling_CheckerPublic_retains_identity
    self.assertTrue(_pickle.loads(_pickle.dumps(CheckerPublic))
  File "//pypy/lib_pypy/cPickle.py", line 124, in dumps
    Pickler(file, protocol).dump(obj)
  File "//pypy/lib-python/2.7/pickle.py", line 224, in dump
    self.save(obj)
  File "//pypy/lib-python/2.7/pickle.py", line 317, in save
    self.save_global(obj, rv)
  File "//pypy/lib-python/2.7/pickle.py", line 792, in save_global
    (obj, module, name))
PicklingError: Can't pickle Global(CheckerPublic,zope.security.checker): it's not found as zope.security.proxy.CheckerPublic
```

This PR changes just enough to fix that test by special-casing the three attribute names involved in the Python implementation.

Although no more tests fail, there are now probably other behaviour differences between the C and Python implementations. But mostly things that didn't work with the C implementation and subclasses should now work with the Python implementation, and it seems unlikely to me that that will be a compatibility issue (subclasses of this proxy implementation probably being rare?). 