### PR TITLE
Fix iteration in Python3 pure-python implementation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 4.0.3 (unreleased)
 ------------------
 
-- TBD
+- Fixed iteration over security proxies in Python 3 using the
+  pure-Python implementation.
 
 4.0.2 (2015-06-02)
 ------------------

--- a/src/zope/security/checker.py
+++ b/src/zope/security/checker.py
@@ -604,7 +604,7 @@ _typeChecker = NamesChecker(
      '__implemented__'])
 _namedChecker = NamesChecker(['__name__'])
 
-_iteratorChecker = NamesChecker(['next', '__iter__', '__len__'])
+_iteratorChecker = NamesChecker(['next', '__next__', '__iter__', '__len__'])
 
 _setChecker = NamesChecker(['__iter__', '__len__', '__str__', '__contains__',
                             'copy', 'difference', 'intersection', 'issubset',
@@ -651,7 +651,7 @@ _basic_types = {
     datetime.time: NoProxy,
     datetime.tzinfo: NoProxy,
 }
-if PYTHON2: 
+if PYTHON2:
     _basic_types[long] = NoProxy
     _basic_types[unicode] = NoProxy
 else: #pragma NO COVER
@@ -783,4 +783,3 @@ except ImportError: #pragma NO COVER
     pass
 else:
     addCleanUp(_clear)
-

--- a/src/zope/security/tests/test_checker.py
+++ b/src/zope/security/tests/test_checker.py
@@ -620,7 +620,7 @@ class Test_MultiChecker(unittest.TestCase):
         class IFoo(Interface):
             bar = Attribute('Bar')
         other_perm = object()
-        checker = self._callFUT([(IFoo, other_perm), 
+        checker = self._callFUT([(IFoo, other_perm),
                                  (('foo', 'baz'), CheckerPublic)])
         self.assertTrue(checker.permission_id('foo') is CheckerPublic)
         self.assertTrue(checker.permission_id('bar') is other_perm)
@@ -636,7 +636,7 @@ class Test_MultiChecker(unittest.TestCase):
             bar = Attribute('Bar')
         other_perm = object()
         self.assertRaises(DuplicationError,
-                          self._callFUT, [(IFoo, other_perm), 
+                          self._callFUT, [(IFoo, other_perm),
                                           (('foo', 'bar'), CheckerPublic)])
 
     def test_w_spec_as_mapping(self):
@@ -784,7 +784,7 @@ class Test_getCheckerForInstancesOf(unittest.TestCase):
         from zope.security.checker import _checkers
         class Foo(object):
             pass
-        checker = _checkers[Foo] = object() 
+        checker = _checkers[Foo] = object()
         self.assertTrue(self._callFUT(Foo) is checker)
 
 
@@ -1362,7 +1362,7 @@ class BasicTypesTests(unittest.TestCase):
         BasicTypes.update({Foo:  checker})
         self.assertTrue(BasicTypes[Foo] is checker)
         self.assertTrue(_checkers[Foo] is checker)
- 
+
 
 # Pre-geddon tests start here
 
@@ -1600,6 +1600,15 @@ class Test(unittest.TestCase):
             #
             #    proxy2 = checker.proxy(proxy)
             #    self.assertTrue(proxy2 is proxy, [proxy, proxy2])
+
+    def test_iteration(self):
+        from zope.security.checker import ProxyFactory
+        from zope.security.checker import selectChecker
+
+        for i in ((1,), [1]):
+            _iter = iter(i)
+            proxy = ProxyFactory(_iter, selectChecker(_iter))
+            self.assertEqual(next(proxy), 1)
 
     def testLayeredProxies(self):
         #Test that a Proxy will not be re-proxied.


### PR DESCRIPTION
Fixes zopefoundation/zope.component#16.

Python 3 looks for `__next__` but only `next` was allowed to be public. This caused [this error](https://travis-ci.org/zopefoundation/zope.component/jobs/64425022).