### PR TITLE
Fix iteration of BTrees.items() in pure-python; and 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ matrix:
   include:
     - python: 3.5
       env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
 env:
     - TOXENV=py27
     - TOXENV=py27-pure
@@ -11,12 +13,13 @@ env:
     - TOXENV=py33-pure
     - TOXENV=py34
     - TOXENV=pypy
-    - TOXENV=pypy3
     - TOXENV=coverage
     - TOXENV=docs
 install:
-    - pip install tox
+    - pip install -U pip
+    - pip install -U setuptools tox
 script:
     - tox
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,14 @@ Changes
 
 - Drop support for Python 2.6 and 3.2.
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
+
+- Fix iteration of pure-Python BTrees.items(). See `issue 20
+  <https://github.com/zopefoundation/zope.security/issues/20>`_.
+
+- Fix creating a list from a BTrees.items() on Python 3.  See `issue 20
+  <https://github.com/zopefoundation/zope.security/issues/20>`_.
+
 
 4.0.3 (2015-06-02)
 ------------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,8 @@ install:
 # to delete a .pyd that was still open.
   - pip install persistent
   - pip install BTrees
-  - pip install -e .[test]
+  - pip install zope.testrunner
+  - pip install .[test]
 
 build: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,18 +9,25 @@ environment:
     - python : 34-x64
     - python : 35
     - python : 35-x64
+    - python : 36
+    - python : 36-x64
     - { python: 27, PURE_PYTHON: 1 }
     - { python: 35, PURE_PYTHON: 1 }
 
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
   - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
-  - pip install -e .
+# We need to install the C extensions that BTrees setup-requires
+# separately because we've seen problems with the BTrees build cleanup step trying
+# to delete a .pyd that was still open.
+  - pip install persistent
+  - pip install BTrees
+  - pip install -e .[test]
 
 build: false
 
 test_script:
-  - python setup.py -q test -q
+  - python -m zope.testrunner --test-path=src
 
 on_success:
   - echo Build succesful!

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 TESTS_REQUIRE = [
+    'BTrees',
     'zope.component',
     'zope.configuration',
     'zope.location',
@@ -50,7 +51,8 @@ def alltests():
 
 here = os.path.abspath(os.path.dirname(__file__))
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
+        return f.read()
 
 # Include directories for C extensions
 # Sniff the location of the headers in 'persistent' or fall back
@@ -114,8 +116,8 @@ setup(name='zope.security',
           + '\n\n' +
           read('CHANGES.rst')
           ),
-      keywords = "zope security policy principal permission",
-      classifiers = [
+      keywords="zope security policy principal permission",
+      classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Web Environment',
           'Intended Audience :: Developers',
@@ -127,12 +129,14 @@ setup(name='zope.security',
           'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Topic :: Internet :: WWW/HTTP',
-          'Framework :: Zope3'],
+          'Framework :: Zope3',
+      ],
       url='http://pypi.python.org/pypi/zope.security',
       license='ZPL 2.1',
       packages=find_packages('src'),
@@ -140,14 +144,15 @@ setup(name='zope.security',
       namespace_packages=['zope'],
       setup_requires=setup_requires,
       ext_modules=ext_modules,
-      install_requires=['setuptools',
-                        'zope.component',
-                        'zope.i18nmessageid',
-                        'zope.interface',
-                        'zope.location',
-                        'zope.proxy >= 4.1.0',
-                        'zope.schema',
-                        ],
+      install_requires=[
+          'setuptools',
+          'zope.component',
+          'zope.i18nmessageid',
+          'zope.interface',
+          'zope.location',
+          'zope.proxy >= 4.1.0',
+          'zope.schema',
+      ],
       test_suite = '__main__.alltests',
       tests_require=TESTS_REQUIRE,
       extras_require = dict(
@@ -157,7 +162,7 @@ setup(name='zope.security',
           test=TESTS_REQUIRE,
           testing=TESTS_REQUIRE + ['nose', 'coverage'],
           docs=['Sphinx', 'repoze.sphinx.autointerface'],
-          ),
+      ),
       include_package_data = True,
       zip_safe = False,
       )

--- a/tox.ini
+++ b/tox.ini
@@ -3,19 +3,13 @@ envlist =
 # Jython support pending 2.7 support, due 2012-07-15 or so.  See:
 # http://fwierzbicki.blogspot.com/2012/03/adconion-to-fund-jython-27.html
 #   py27,pypy,jython,py33,coverage,docs
-    py27,py27-pure,pypy,py33,py33-pure,py34,py35,coverage,docs
+    py27,py27-pure,pypy,py33,py33-pure,py34,py35,py36,coverage,docs
 
 [testenv]
 deps =
-    zope.interface
-    zope.testing
-    zope.configuration
-    zope.component
-    zope.location
-    zope.proxy
-    zope.testrunner
+    .[test]
 commands =
-    python setup.py -q test -q
+    zope-testrunner --test-path=src --auto-progress --auto-color []
 
 [testenv:py27-pure]
 basepython =
@@ -43,28 +37,15 @@ commands =
     pip install -e .
     nosetests --with-xunit --with-xcoverage
 deps =
-    zope.interface
-    zope.testing
-    zope.configuration
-    zope.component
-    zope.location
-    zope.proxy
-    nose
+    .[testing]
     coverage
     nosexcover
 
 [testenv:docs]
 basepython =
-    python3.3
+    python3.4
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 deps =
-    zope.interface
-    zope.testing
-    zope.configuration
-    zope.component
-    zope.location
-    zope.proxy
-    Sphinx
-    repoze.sphinx.autointerface
+    .[docs,test]


### PR DESCRIPTION
Also fix ``list(proxy_btree.items())`` (or a list comprehension of the same) in Python 3, which wants the ``__len__`` for a hint.

This is a central place to make sure these all behave consistently.

Fixes #20