### PR TITLE
Be specific that BTrees.keys and .values also are fixed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ Changes
 
 - Fix `issue 20 <https://github.com/zopefoundation/zope.security/issues/20>`_:
   iteration of pure-Python ``BTrees.items()``, and also creating a list from
-  ``BTrees.items()`` on Python 3.
+  ``BTrees.items()`` on Python 3. The same applies for ``keys()`` and ``values()``.
 
 4.0.3 (2015-06-02)
 ------------------

--- a/src/zope/security/checker.py
+++ b/src/zope/security/checker.py
@@ -781,7 +781,8 @@ else:
     # to do iteration. Whitelist it so that they behave the same.
     # In addition, Python 3 will attempt to call __len__ on iterators
     # for a length hint, so the C implementations also need to be
-    # added to the _iteratorChecker.
+    # added to the _iteratorChecker. The same thing automatically
+    # applies for .keys() and .values() since they return the same type.
     # We do this here so that all users of zope.security can benefit
     # without knowing implementation details.
     # See https://github.com/zopefoundation/zope.security/issues/20

--- a/src/zope/security/tests/test_checker.py
+++ b/src/zope/security/tests/test_checker.py
@@ -399,7 +399,9 @@ class CheckerTestsBase(object):
         from zope.security.checker import CheckerPublic
         import BTrees
 
-        checker = Checker({'items': CheckerPublic})
+        checker = Checker({'items': CheckerPublic,
+                           'keys': CheckerPublic,
+                           'values': CheckerPublic})
 
         for name in ('IF', 'II', 'IO', 'OI', 'OO'):
             for family_name in ('family32', 'family64'):
@@ -408,10 +410,14 @@ class CheckerTestsBase(object):
                 proxy = Proxy(btree, checker)
                 # empty
                 self.assertEqual([], list(proxy.items()))
+                self.assertEqual([], list(proxy.keys()))
+                self.assertEqual([], list(proxy.values()))
 
                 # With an object
                 btree[1] = 2
                 self.assertEqual([(1, 2)], list(proxy.items()))
+                self.assertEqual([1], list(proxy.keys()))
+                self.assertEqual([2], list(proxy.values()))
 
 
 class CheckerPyTests(unittest.TestCase, CheckerTestsBase):


### PR DESCRIPTION
In the same way that .items was. See #20 and #21.