### PR TITLE
OrderedDict, BTree and dict all iterate the same way.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ Changes
 4.1.1 (unreleased)
 ------------------
 
-- TBD
+- Fix `issue 23 <https://github.com/zopefoundation/zope.security/issues/23>`_:
+  iteration of ``collections.OrderedDict`` and its various views is
+  now allowed by default on all versions of Python.
+
+- As a further fix for issue 20, iteration of BTree itself is now
+  allowed by default.
 
 4.1.0 (2017-04-24)
 ------------------


### PR DESCRIPTION
Fixes #23. Also a further fix for #20 (you couldn't iterate a BTree all by itself).

Refactor the test case for BTree to be a shared implementation and confirm that it works as expected for dict, using the actual dict checker. Then apply it to OrderedDict and BTree and fix the resulting
failures by refactoring the fixup in checker.py to a shared implementation and applying it.