### PR TITLE
Fix TypeError handling for ProxyPy.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changes
 4.1.2 (unreleased)
 ------------------
 
+- Fix `issue 7
+  <https://github.com/zopefoundation/zope.security/issues/7`_: The
+  pure-Python proxy didn't propagate ``TypeError`` from ``__repr__``
+  and ``__str__`` like the C implementation did.
+
 - Fix `issue 27 <https://github.com/zopefoundation/zope.security/issues/27>`_:
   iteration of ``zope.interface.providedBy()`` is now allowed by
   default on all versions of Python. Previously it only worked on

--- a/src/zope/security/proxy.py
+++ b/src/zope/security/proxy.py
@@ -219,6 +219,11 @@ class ProxyPy(PyProxyBase):
     def __str__(self):
         try:
             return _check_name(PyProxyBase.__str__)(self)
+        # The C implementation catches almost all exceptions; the
+        # exception is a TypeError that's raised when the repr returns
+        # the wrong type of object.
+        except TypeError:
+            raise
         except:
             # The C implementation catches all exceptions.
             wrapped = super(PyProxyBase, self).__getattribute__('_wrapped')
@@ -229,8 +234,12 @@ class ProxyPy(PyProxyBase):
     def __repr__(self):
         try:
             return _check_name(PyProxyBase.__repr__)(self)
+        # The C implementation catches almost all exceptions; the
+        # exception is a TypeError that's raised when the repr returns
+        # the wrong type of object.
+        except TypeError:
+            raise
         except:
-            # The C implementation catches all exceptions.
             wrapped = super(PyProxyBase, self).__getattribute__('_wrapped')
             return '<security proxied %s.%s instance at %s>' %(
                 wrapped.__class__.__module__, wrapped.__class__.__name__,


### PR DESCRIPTION
Also add additional tests clarifying how the str-to-repr fallthrough works.

Fixes #7

Minor test cleanups in test_proxy.py: PyPy 2.5.0 is *long* gone so we don't need to deal with that anymore. Use `unittest.skip*` instead of manual replacement functions; this helps coverage numbers.