### PR TITLE
Simplify _compat.py now that we only run on newer Pythons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ Changes
   default. In addition, iteration of all the custom iterator types
   defined in itertools are also allowed by default.
 
+- Simplify the internal ``_compat.py`` module now that we only run on
+  newer Python versions. See `PR 32 <https://github.com/zopefoundation/zope.security/pull/32>`_.
+
 4.1.1 (2017-05-17)
 ------------------
 

--- a/src/zope/security/_compat.py
+++ b/src/zope/security/_compat.py
@@ -22,15 +22,7 @@ py_impl = getattr(platform, 'python_implementation', lambda: None)
 PYPY = py_impl() == 'PyPy'
 PURE_PYTHON = os.environ.get('PURE_PYTHON', False)
 
-if sys.version_info[0] < 3: #pragma NO COVER
-
-    from StringIO import StringIO
-    import cPickle as _pickle
-
-    reload = reload
-
-    def _u(s):
-        return unicode(s, 'unicode_escape')
+if sys.version_info[0] < 3: # pragma: no cover
 
     CLASS_TYPES = (type, types.ClassType)
     _BUILTINS = '__builtin__'
@@ -38,17 +30,7 @@ if sys.version_info[0] < 3: #pragma NO COVER
     PYTHON3 = False
     PYTHON2 = True
 
-    TEXT = unicode
-
-else: #pragma NO COVER
-
-    from io import StringIO
-    import pickle as _pickle
-
-    from imp import reload
-
-    def _u(s):
-        return s
+else: # pragma: no cover
 
     CLASS_TYPES = (type,)
     _BUILTINS = 'builtins'
@@ -56,6 +38,5 @@ else: #pragma NO COVER
     PYTHON3 = True
     PYTHON2 = False
 
-    TEXT = str
 
-_BLANK = _u('')
+_BLANK = u''

--- a/src/zope/security/_compat.py
+++ b/src/zope/security/_compat.py
@@ -20,7 +20,7 @@ import types
 
 py_impl = getattr(platform, 'python_implementation', lambda: None)
 PYPY = py_impl() == 'PyPy'
-PURE_PYTHON = os.environ.get('PURE_PYTHON', False)
+PURE_PYTHON = os.environ.get('PURE_PYTHON', PYPY)
 
 if sys.version_info[0] < 3: # pragma: no cover
 

--- a/src/zope/security/_definitions.py
+++ b/src/zope/security/_definitions.py
@@ -17,12 +17,11 @@ import threading
 import zope.interface
 
 from zope.security import interfaces
-from zope.security._compat import _u
 
 thread_local = threading.local()
 
 @zope.interface.provider(interfaces.IPrincipal)
 class system_user(object):
-    id = _u('zope.security.management.system_user')
-    title = _u('System')
-    description = _u('')
+    id = u'zope.security.management.system_user'
+    title = u'System'
+    description = u''

--- a/src/zope/security/checker.py
+++ b/src/zope/security/checker.py
@@ -49,7 +49,6 @@ from zope.security.interfaces import Unauthorized
 from zope.security._definitions import thread_local
 from zope.security._compat import CLASS_TYPES
 from zope.security._compat import PYTHON2
-from zope.security._compat import _u
 from zope.security.proxy import Proxy
 from zope.security.proxy import getChecker
 
@@ -687,7 +686,7 @@ BasicTypes_examples = {
 }
 
 if PYTHON2:
-    BasicTypes_examples[unicode] = _u('uabc')
+    BasicTypes_examples[unicode] = u'uabc'
     BasicTypes_examples[long] = long(65536)
 
 

--- a/src/zope/security/metadirectives.py
+++ b/src/zope/security/metadirectives.py
@@ -25,7 +25,6 @@ from zope.interface import Interface
 import zope.security.zcml
 from zope.security.i18n import ZopeMessageFactory as _
 from zope.security.zcml import Permission
-from zope.security._compat import _u
 
 class IClassDirective(zope.interface.Interface):
     """Make statements about a class"""
@@ -149,8 +148,8 @@ class IModule(Interface):
     """Group security declarations about a module"""
 
     module = GlobalObject(
-        title=_u("Module"),
-        description=_u("Pointer to the module object."),
+        title=u"Module",
+        description=u"Pointer to the module object.",
         required=True)
 
 
@@ -163,17 +162,17 @@ class IAllow(Interface):
     """
 
     attributes = Tokens(
-        title=_u("Attributes"),
-        description=_u("The attributes to provide access to."),
-        value_type = PythonIdentifier(),
+        title=u"Attributes",
+        description=u"The attributes to provide access to.",
+        value_type=PythonIdentifier(),
         required=False)
 
     interface = Tokens(
-        title=_u("Interface"),
-        description=_u("Interfaces whos names to provide access to. Access "
-                       "will be provided to all of the names defined by the "
-                       "interface(s). Multiple interfaces can be supplied."),
-        value_type = GlobalInterface(),
+        title=u"Interface",
+        description=(u"Interfaces whos names to provide access to. Access "
+                       u"will be provided to all of the names defined by the "
+                       u"interface(s). Multiple interfaces can be supplied."),
+        value_type=GlobalInterface(),
         required=False)
 
 
@@ -182,15 +181,15 @@ class IRequire(Interface):
 
     The given permission is required to access any names provided
     directly in the attributes attribute or any names defined by
-    interfaces listed in the interface attribute.  
+    interfaces listed in the interface attribute.
     """
 
     attributes = Tokens(
-        title=_u("Attributes"),
-        description=_u("The attributes to require permission for."),
-        value_type = PythonIdentifier(),
+        title=u"Attributes",
+        description=u"The attributes to require permission for.",
+        value_type=PythonIdentifier(),
         required=False)
 
     permission = Permission(
-        title=_u("Permission ID"),
-        description=_u("The id of the permission to require."))
+        title=u"Permission ID",
+        description=u"The id of the permission to require.")

--- a/src/zope/security/permission.py
+++ b/src/zope/security/permission.py
@@ -27,7 +27,6 @@ from zope.schema.vocabulary import SimpleVocabulary
 
 from zope.security.checker import CheckerPublic
 from zope.security.interfaces import IPermission
-from zope.security._compat import _u
 
 @implementer(IPermission)
 class Permission(object):
@@ -49,7 +48,7 @@ def allPermissions(context=None):
     """Get the ids of all defined permissions
     """
     for id, permission in getUtilitiesFor(IPermission, context):
-        if id != _u('zope.Public'):
+        if id != u'zope.Public':
             yield id
 
 def PermissionsVocabulary(context=None):
@@ -85,7 +84,7 @@ def PermissionIdsVocabulary(context=None):
             terms.append(SimpleTerm(name, name, name))
     terms = sorted(terms, key=operator.attrgetter('title'))
     if has_public:
-        terms.insert(0, SimpleTerm(CheckerPublic, 'zope.Public', _u('Public')))
+        terms.insert(0, SimpleTerm(CheckerPublic, 'zope.Public', u'Public'))
     return SimpleVocabulary(terms)
 
 directlyProvides(PermissionIdsVocabulary, IVocabularyFactory)

--- a/src/zope/security/tests/test_checker.py
+++ b/src/zope/security/tests/test_checker.py
@@ -868,13 +868,12 @@ class _SelectCheckerBase(object):
     def test_w_basic_types_NoProxy(self):
         import datetime
         from zope.i18nmessageid import Message
-        from zope.security._compat import _u
         msg = Message('msg')
         for obj in [object(),
                     42,
                     3.14,
                     None,
-                    _u('text'),
+                    u'text',
                     b'binary',
                     msg,
                     True,
@@ -1044,13 +1043,12 @@ class Test_defineChecker(unittest.TestCase):
         return defineChecker(type_, checker)
 
     def test_w_wrong_type(self):
-        from zope.security._compat import _u
         checker = object()
         for obj in [object(),
                     42,
                     3.14,
                     None,
-                    _u('text'),
+                    u'text',
                     b'binary',
                     True,
                    ]:
@@ -2108,11 +2106,10 @@ class TestSecurityPolicy(unittest.TestCase):
 class TestCheckerPublic(unittest.TestCase):
 
     def test_that_pickling_CheckerPublic_retains_identity(self):
-        from zope.security._compat import _pickle
+        import pickle
         from zope.security.checker import CheckerPublic
-        self.assertTrue(_pickle.loads(_pickle.dumps(CheckerPublic))
-                     is
-                     CheckerPublic)
+        self.assertIs(pickle.loads(pickle.dumps(CheckerPublic)),
+                      CheckerPublic)
 
     def test_that_CheckerPublic_identity_works_even_when_proxied(self):
         from zope.security.checker import ProxyFactory

--- a/src/zope/security/tests/test_management.py
+++ b/src/zope/security/tests/test_management.py
@@ -172,17 +172,15 @@ class Test(unittest.TestCase):
 
     def test_system_user(self):
         from zope.security.management import system_user
-        from zope.security._compat import TEXT
-        from zope.security._compat import _u
-        self.assertEqual(system_user.id,
-                          _u('zope.security.management.system_user'))
 
-        self.assertEqual(system_user.title, _u('System'))
+        self.assertEqual(system_user.id,
+                         u'zope.security.management.system_user')
+
+        self.assertEqual(system_user.title, u'System')
 
         for name in 'id', 'title', 'description':
-            self.assertTrue(isinstance(getattr(system_user, name), TEXT))
+            self.assertIsInstance(getattr(system_user, name),
+                                  type(u''))
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(Test),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/security/tests/test_metaconfigure.py
+++ b/src/zope/security/tests/test_metaconfigure.py
@@ -218,10 +218,9 @@ class ClassDirectiveTests(unittest.TestCase):
         from zope.schema import Field
         from zope.interface import Interface
         from zope.security.protectclass import protectSetAttribute
-        from zope.security._compat import _u
         class IFoo(Interface):
-            bar = Field(_u("Bar"))
-            baz = Field(_u("Baz"))
+            bar = Field(u"Bar")
+            baz = Field(u"Baz")
         context = DummyZCMLContext()
         directive = self._makeOne(context, Foo)
         directive.require(context, permission='testing', set_schema=[IFoo])
@@ -258,9 +257,8 @@ class ClassDirectiveTests(unittest.TestCase):
         from zope.component.interface import provideInterface
         from zope.schema import Field
         from zope.interface import Interface
-        from zope.security._compat import _u
         class IFoo(Interface):
-            bar = Field(_u("Bar"), readonly=True)
+            bar = Field(u"Bar", readonly=True)
         context = DummyZCMLContext()
         directive = self._makeOne(context, Foo)
         directive.require(context, permission='testing', set_schema=[IFoo])
@@ -650,11 +648,4 @@ class DummyZCMLContext(object):
 
 
 def test_suite():
-    return unittest.TestSuite([
-        unittest.makeSuite(Test_dottedName),
-        unittest.makeSuite(ClassDirectiveTests),
-        unittest.makeSuite(Test_protectModule),
-        unittest.makeSuite(Test_allow),
-        unittest.makeSuite(Test_allow),
-    ])
-
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/security/tests/test_proxy.py
+++ b/src/zope/security/tests/test_proxy.py
@@ -1996,7 +1996,11 @@ class LocationProxySecurityCheckerTests(unittest.TestCase):
         import sys
         from zope.location.location import LocationProxy
         import zope.security
-        from zope.security._compat import reload
+        try:
+            from imp import reload
+        except ImportError:
+            reload = reload # Python 2
+
         # This attribute is set when zope.security.decorator is imported, to
         # show that it will be set too, if zope.security.proxy is imported
         # we set it to a different value at first:

--- a/src/zope/security/zcml.py
+++ b/src/zope/security/zcml.py
@@ -24,7 +24,6 @@ from zope.schema.interfaces import IFromUnicode
 
 from zope.security.permission import checkPermission
 from zope.security.management import setSecurityPolicy
-from zope.security._compat import _u
 
 @implementer(IFromUnicode)
 class Permission(Id):
@@ -42,9 +41,9 @@ class Permission(Id):
 
         if value != 'zope.Public':
             self.context.action(
-                discriminator = None,
-                callable = checkPermission,
-                args = (None, value),
+                discriminator=None,
+                callable=checkPermission,
+                args=(None, value),
 
                 # Delay execution till end. This is an
                 # optimization. We don't want to intersperse utility
@@ -53,39 +52,40 @@ class Permission(Id):
                 # utility definition, as extensive caches have to be
                 # rebuilt.
                 order=9999999,
-                )
+            )
 
 
 class ISecurityPolicyDirective(Interface):
     """Defines the security policy that will be used for Zope."""
 
     component = GlobalObject(
-        title=_u("Component"),
-        description=_u("Pointer to the object that will handle the security."),
+        title=u"Component",
+        description=u"Pointer to the object that will handle the security.",
         required=True)
 
 def securityPolicy(_context, component):
     _context.action(
-            discriminator = 'defaultPolicy',
-            callable = setSecurityPolicy,
-            args = (component,) )
+        discriminator='defaultPolicy',
+        callable=setSecurityPolicy,
+        args=(component,)
+    )
 
 class IPermissionDirective(Interface):
     """Define a new security object."""
 
     id = Id(
-        title=_u("Id"),
-        description=_u("Id as which this object will be known and used."),
+        title=u"Id",
+        description=u"Id as which this object will be known and used.",
         required=True)
 
     title = MessageID(
-        title=_u("Title"),
-        description=_u("Provides a title for the object."),
+        title=u"Title",
+        description=u"Provides a title for the object.",
         required=True)
 
     description = MessageID(
-        title=_u("Description"),
-        description=_u("Provides a description for the object."),
+        title=u"Description",
+        description=u"Provides a description for the object.",
         required=False)
 
 def permission(_context, id, title, description=''):
@@ -99,13 +99,13 @@ class IRedefinePermission(Interface):
     """Define a permission to replace another permission."""
 
     from_ = Permission(
-        title=_u("Original permission"),
-        description=_u("Original permission id to redefine."),
+        title=u"Original permission",
+        description=u"Original permission id to redefine.",
         required=True)
 
     to = Permission(
-        title=_u("Substituted permission"),
-        description=_u("Substituted permission id."),
+        title=u"Substituted permission",
+        description=u"Substituted permission id.",
         required=True)
 
 def redefinePermission(_context, from_, to):
@@ -113,6 +113,6 @@ def redefinePermission(_context, from_, to):
 
     # check if context has any permission mappings yet
     if not hasattr(_context, 'permission_mapping'):
-        _context.permission_mapping={}
+        _context.permission_mapping = {}
 
     _context.permission_mapping[from_] = to


### PR DESCRIPTION
- We have u'literals' so we don't need a _u() function.

  For the record the Emacs replacement regex was  `_u(\(['"]\)\([^)]*\)\1) -> u\1\2\1`. Amazingly, I typed that right  on the first try.

A few things were only used in one (test) file or function, so it was better to keep the use, if any, local and out of the "public" api:

- We can use `io.StringIO` everywhere (and it's fast now all versions have an accelerated implementation). It was only  imported in one file anyway. This is the way of the future.
- We can just import pickle. It was only imported in one file anyway. This is the way of the future.
- TEXT was only used in one test function, `type(u'')` is pretty much just as clear (especially since the usual name is `text_type`).
- reload was only used in one test function, so move the definition there.