### PR TITLE
Use features and an optional_build_ext

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,9 @@ Changes
 - Simplify the internal ``_compat.py`` module now that we only run on
   newer Python versions. See `PR 32 <https://github.com/zopefoundation/zope.security/pull/32>`_.
 
-- Respect ``PURE_PYTHON`` at runtime. See `issue 33
+- Respect ``PURE_PYTHON`` at runtime. At build time, always try to
+  build the C extensions on supported platforms, ignoring
+  ``PURE_PYTHON``. See `issue 33
   <https://github.com/zopefoundation/zope.security/issues/33>`_.
 
 - Fix watching checkers (``ZOPE_WATCH_CHECKERS=1``) in pure-Python


### PR DESCRIPTION
Just like zope.interface (copied from there).

The Feature may be overkill given the optional nature of building the extensions now?

Fixes #33.

This should eliminate any chance of polluting (local) wheel caches if PURE_PYTHON happens to be defined (theoretically features can be controlled somewhere with `--with-X` and `--without-X` options, but that doesn't actually seem to work anywhere.