### PR TITLE
Promote the constant for zope.Public from metaconfigure.py to interfaces.py

### DIFF
--- a/src/zope/security/interfaces.py
+++ b/src/zope/security/interfaces.py
@@ -19,14 +19,18 @@ from zope.interface.common.interfaces import IException, IAttributeError
 from zope.schema import Text, TextLine
 from zope.security.i18n import ZopeMessageFactory as _
 
+#: The name (id) of the registered :class:`IPermission` utility that signifies
+#: that the protected attribute is public.
+#:
+#: .. versionadded:: 4.2.0
+PUBLIC_PERMISSION_NAME = 'zope.Public'
+
 class IUnauthorized(IException):
     pass
 
 @implementer(IUnauthorized)
 class Unauthorized(Exception):
     """Some user wasn't allowed to access a resource"""
-
-
 
 class IForbidden(IException):
     pass

--- a/src/zope/security/metaconfigure.py
+++ b/src/zope/security/metaconfigure.py
@@ -32,8 +32,8 @@ from zope.security.checker import moduleChecker
 from zope.security.protectclass import protectLikeUnto
 from zope.security.protectclass import protectName
 from zope.security.protectclass import protectSetAttribute
+from zope.security.interfaces import PUBLIC_PERMISSION_NAME as PublicPermission
 
-PublicPermission = 'zope.Public'
 
 def dottedName(klass):
     if klass is None:
@@ -186,7 +186,7 @@ def protectModule(module, name, permission):
         checker = Checker({}, {})
         defineChecker(module, checker)
 
-    if permission == 'zope.Public':
+    if permission == PublicPermission:
         # Translate public permission to CheckerPublic
         permission = CheckerPublic
 
@@ -215,7 +215,7 @@ def allow(context, attributes=(), interface=()):
             discriminator=('http://namespaces.zope.org/zope:module',
                            context.module, name),
             callable=protectModule,
-            args=(context.module, name, 'zope.Public'),
+            args=(context.module, name, PublicPermission),
         )
 
 

--- a/src/zope/security/permission.py
+++ b/src/zope/security/permission.py
@@ -27,6 +27,7 @@ from zope.schema.vocabulary import SimpleVocabulary
 
 from zope.security.checker import CheckerPublic
 from zope.security.interfaces import IPermission
+from zope.security.interfaces import PUBLIC_PERMISSION_NAME as zope_Public
 
 @implementer(IPermission)
 class Permission(object):
@@ -48,7 +49,7 @@ def allPermissions(context=None):
     """Get the ids of all defined permissions
     """
     for name, _permission in getUtilitiesFor(IPermission, context):
-        if name != u'zope.Public':
+        if name != zope_Public:
             yield name
 
 def PermissionsVocabulary(context=None):
@@ -78,13 +79,13 @@ def PermissionIdsVocabulary(context=None):
     terms = []
     has_public = False
     for name, _permission in getUtilitiesFor(IPermission, context):
-        if name == 'zope.Public':
+        if name == zope_Public:
             has_public = True
         else:
             terms.append(SimpleTerm(name, name, name))
     terms = sorted(terms, key=operator.attrgetter('title'))
     if has_public:
-        terms.insert(0, SimpleTerm(CheckerPublic, 'zope.Public', u'Public'))
+        terms.insert(0, SimpleTerm(CheckerPublic, zope_Public, u'Public'))
     return SimpleVocabulary(terms)
 
 directlyProvides(PermissionIdsVocabulary, IVocabularyFactory)

--- a/src/zope/security/protectclass.py
+++ b/src/zope/security/protectclass.py
@@ -18,6 +18,7 @@ from zope.security.checker import Checker
 from zope.security.checker import CheckerPublic
 from zope.security.checker import defineChecker
 from zope.security.checker import getCheckerForInstancesOf
+from zope.security.interfaces import PUBLIC_PERMISSION_NAME as zope_Public
 
 
 def protectName(class_, name, permission):
@@ -28,7 +29,7 @@ def protectName(class_, name, permission):
         checker = Checker({}, {})
         defineChecker(class_, checker)
 
-    if permission == 'zope.Public':
+    if permission == zope_Public:
         # Translate public permission to CheckerPublic
         permission = CheckerPublic
 
@@ -43,7 +44,7 @@ def protectSetAttribute(class_, name, permission):
         checker = Checker({}, {})
         defineChecker(class_, checker)
 
-    if permission == 'zope.Public':
+    if permission == zope_Public:
         # Translate public permission to CheckerPublic
         permission = CheckerPublic
 

--- a/src/zope/security/testing.py
+++ b/src/zope/security/testing.py
@@ -24,6 +24,7 @@ from zope.security import interfaces
 from zope.security.permission import Permission
 import zope.security.management
 from zope.security._compat import PYTHON2 as PY2
+from zope.security.interfaces import PUBLIC_PERMISSION_NAME
 
 from zope.testing import renormalizing
 
@@ -59,7 +60,8 @@ def addCheckerPublic():
     """Add the CheckerPublic permission as 'zope.Public'"""
 
     perm = Permission(
-        'zope.Public', 'Public',
+        PUBLIC_PERMISSION_NAME,
+        'Public',
         """Special permission used for resources that are always public
 
         The public permission is effectively an optimization, sine

--- a/src/zope/security/tests/test_metaconfigure.py
+++ b/src/zope/security/tests/test_metaconfigure.py
@@ -14,6 +14,7 @@
 """Test ZCML directives
 """
 import unittest
+from zope.security.interfaces import PUBLIC_PERMISSION_NAME as zope_Public
 
 class Test_dottedName(unittest.TestCase):
 
@@ -110,8 +111,6 @@ class ClassDirectiveTests(unittest.TestCase):
 
     def test_require_only_permission(self):
         from zope.configuration.exceptions import ConfigurationError
-        class Bar(object):
-            pass
         context = DummyZCMLContext()
         directive = self._makeOne(context, Foo)
         self.assertRaises(ConfigurationError,
@@ -119,8 +118,6 @@ class ClassDirectiveTests(unittest.TestCase):
 
     def test_require_no_like_class_wo_permission(self):
         from zope.configuration.exceptions import ConfigurationError
-        class Bar(object):
-            pass
         context = DummyZCMLContext()
         directive = self._makeOne(context, Foo)
         self.assertRaises(ConfigurationError,
@@ -270,8 +267,6 @@ class ClassDirectiveTests(unittest.TestCase):
 
     def test_allow_no_attributes_or_interface(self):
         from zope.configuration.exceptions import ConfigurationError
-        class Bar(object):
-            pass
         context = DummyZCMLContext()
         directive = self._makeOne(context, Foo)
         self.assertRaises(ConfigurationError, directive.allow, context)
@@ -292,12 +287,12 @@ class ClassDirectiveTests(unittest.TestCase):
                          ('protectName', Foo, 'bar'))
         self.assertTrue(context._actions[0]['callable'] is protectName)
         self.assertEqual(context._actions[0]['args'],
-                         (Foo, 'bar', 'zope.Public'))
+                         (Foo, 'bar', zope_Public))
         self.assertEqual(context._actions[1]['discriminator'],
                          ('protectName', Foo, 'baz'))
         self.assertTrue(context._actions[1]['callable'] is protectName)
         self.assertEqual(context._actions[1]['args'],
-                         (Foo, 'baz', 'zope.Public'))
+                         (Foo, 'baz', zope_Public))
         self.assertTrue(context._actions[2]['discriminator'] is None)
         self.assertTrue(context._actions[2]['callable'] is provideInterface)
         self.assertEqual(context._actions[2]['args'],
@@ -320,7 +315,7 @@ class ClassDirectiveTests(unittest.TestCase):
                          ('protectName', Foo, 'bar'))
         self.assertTrue(context._actions[0]['callable'] is protectName)
         self.assertEqual(context._actions[0]['args'],
-                         (Foo, 'bar', 'zope.Public'))
+                         (Foo, 'bar', zope_Public))
         self.assertTrue(context._actions[1]['discriminator'] is None)
         self.assertTrue(context._actions[1]['callable'] is provideInterface)
         self.assertEqual(context._actions[1]['args'],
@@ -329,7 +324,7 @@ class ClassDirectiveTests(unittest.TestCase):
                          ('protectName', Foo, 'baz'))
         self.assertTrue(context._actions[2]['callable'] is protectName)
         self.assertEqual(context._actions[2]['args'],
-                         (Foo, 'baz', 'zope.Public'))
+                         (Foo, 'baz', zope_Public))
         self.assertTrue(context._actions[3]['discriminator'] is None)
         self.assertTrue(context._actions[3]['callable'] is provideInterface)
         self.assertEqual(context._actions[3]['args'],
@@ -345,12 +340,12 @@ class ClassDirectiveTests(unittest.TestCase):
                          ('protectName', Foo, 'bar'))
         self.assertTrue(context._actions[0]['callable'] is protectName)
         self.assertEqual(context._actions[0]['args'],
-                         (Foo, 'bar', 'zope.Public'))
+                         (Foo, 'bar', zope_Public))
         self.assertEqual(context._actions[1]['discriminator'],
                          ('protectName', Foo, 'baz'))
         self.assertTrue(context._actions[1]['callable'] is protectName)
         self.assertEqual(context._actions[1]['args'],
-                         (Foo, 'baz', 'zope.Public'))
+                         (Foo, 'baz', zope_Public))
 
     def test___call__(self):
         context = DummyZCMLContext()
@@ -439,7 +434,7 @@ class Test_protectModule(unittest.TestCase):
         from zope.security.checker import CheckerPublic
         from zope.security.checker import _checkers
         before = _checkers[module] = Checker({'other': CheckerPublic})
-        self._callFUT(module, 'name', 'zope.Public')
+        self._callFUT(module, 'name', zope_Public)
         checker = _checkers[module]
         self.assertTrue(checker is before)
         self.assertTrue(checker.get_permissions['name'] is CheckerPublic)
@@ -482,13 +477,13 @@ class Test_allow(unittest.TestCase):
                           'testing', 'foo'))
         self.assertTrue(context._actions[0]['callable'] is protectModule)
         self.assertEqual(context._actions[0]['args'],
-                         ('testing', 'foo', 'zope.Public'))
+                         ('testing', 'foo', zope_Public))
         self.assertEqual(context._actions[1]['discriminator'],
                          ('http://namespaces.zope.org/zope:module',
                           'testing', 'bar'))
         self.assertTrue(context._actions[1]['callable'] is protectModule)
         self.assertEqual(context._actions[1]['args'],
-                         ('testing', 'bar', 'zope.Public'))
+                         ('testing', 'bar', zope_Public))
 
     def test_w_interface(self):
         from zope.interface import Attribute
@@ -505,7 +500,7 @@ class Test_allow(unittest.TestCase):
                           'testing', 'bar'))
         self.assertTrue(context._actions[0]['callable'] is protectModule)
         self.assertEqual(context._actions[0]['args'],
-                         ('testing', 'bar', 'zope.Public'))
+                         ('testing', 'bar', zope_Public))
 
     def test_w_both(self):
         from zope.interface import Attribute
@@ -524,19 +519,19 @@ class Test_allow(unittest.TestCase):
                           'testing', 'foo'))
         self.assertTrue(context._actions[0]['callable'] is protectModule)
         self.assertEqual(context._actions[0]['args'],
-                         ('testing', 'foo', 'zope.Public'))
+                         ('testing', 'foo', zope_Public))
         self.assertEqual(context._actions[1]['discriminator'],
                          ('http://namespaces.zope.org/zope:module',
                           'testing', 'bar'))
         self.assertTrue(context._actions[1]['callable'] is protectModule)
         self.assertEqual(context._actions[1]['args'],
-                         ('testing', 'bar', 'zope.Public'))
+                         ('testing', 'bar', zope_Public))
         self.assertEqual(context._actions[2]['discriminator'],
                          ('http://namespaces.zope.org/zope:module',
                           'testing', 'baz'))
         self.assertTrue(context._actions[2]['callable'] is protectModule)
         self.assertEqual(context._actions[2]['args'],
-                         ('testing', 'baz', 'zope.Public'))
+                         ('testing', 'baz', zope_Public))
 
 
 class Test_requre(unittest.TestCase):

--- a/src/zope/security/tests/test_permission.py
+++ b/src/zope/security/tests/test_permission.py
@@ -15,6 +15,7 @@
 """
 import unittest
 from zope.component.testing import PlacelessSetup
+from zope.security.interfaces import PUBLIC_PERMISSION_NAME as zope_Public
 
 class PermissionTests(unittest.TestCase):
 
@@ -94,7 +95,7 @@ class Test_allPermissions(PlacelessSetup, unittest.TestCase):
         from zope.security.interfaces import IPermission
         permission = object()
         provideUtility(permission, IPermission, 'testing')
-        provideUtility(CheckerPublic, IPermission, 'zope.Public')
+        provideUtility(CheckerPublic, IPermission, zope_Public)
         self.assertEqual(list(self._callFUT()), ['testing'])
 
 
@@ -126,10 +127,10 @@ class Test_PermissionsVocabulary(PlacelessSetup, unittest.TestCase):
         from zope.security.interfaces import IPermission
         permission = object()
         provideUtility(permission, IPermission, 'testing')
-        provideUtility(CheckerPublic, IPermission, 'zope.Public')
+        provideUtility(CheckerPublic, IPermission, zope_Public)
         vocabulary = self._callFUT()
         self.assertEqual(sorted([x.token for x in vocabulary]),
-                         ['testing', 'zope.Public'])
+                         ['testing', zope_Public])
 
 
 class Test_PermissionIdsVocabulary(PlacelessSetup, unittest.TestCase):
@@ -161,12 +162,12 @@ class Test_PermissionIdsVocabulary(PlacelessSetup, unittest.TestCase):
         from zope.security.interfaces import IPermission
         permission = object()
         provideUtility(permission, IPermission, 'testing')
-        provideUtility(CheckerPublic, IPermission, 'zope.Public')
+        provideUtility(CheckerPublic, IPermission, zope_Public)
         vocabulary = self._callFUT()
         self.assertEqual([x.value for x in vocabulary],
                          [CheckerPublic, 'testing'])
         self.assertEqual([x.token for x in vocabulary],
-                         ['zope.Public', 'testing'])
+                         [zope_Public, 'testing'])
 
 
 def test_suite():

--- a/src/zope/security/tests/test_protectclass.py
+++ b/src/zope/security/tests/test_protectclass.py
@@ -14,7 +14,7 @@
 """Test handler for 'protectClass' directive
 """
 import unittest
-
+from zope.security.interfaces import PUBLIC_PERMISSION_NAME as zope_Public
 
 class Test_protectName(unittest.TestCase):
 
@@ -33,7 +33,7 @@ class Test_protectName(unittest.TestCase):
     def test_wo_existing_checker_w_zope_Public(self):
         from zope.security.checker import CheckerPublic
         from zope.security.checker import _checkers
-        self._callFUT(Foo, 'bar', 'zope.Public')
+        self._callFUT(Foo, 'bar', zope_Public)
         self.assertTrue(_checkers[Foo].get_permissions['bar'] is CheckerPublic)
 
     def test_w_existing_checker(self):
@@ -63,7 +63,7 @@ class Test_protectSetAttribute(unittest.TestCase):
     def test_wo_existing_checker_w_zope_Public(self):
         from zope.security.checker import CheckerPublic
         from zope.security.checker import _checkers
-        self._callFUT(Foo, 'bar', 'zope.Public')
+        self._callFUT(Foo, 'bar', zope_Public)
         self.assertTrue(_checkers[Foo].set_permissions['bar'] is CheckerPublic)
 
     def test_w_existing_checker(self):

--- a/src/zope/security/tests/test_testing.py
+++ b/src/zope/security/tests/test_testing.py
@@ -16,6 +16,7 @@ import unittest
 from zope.testing.cleanup import CleanUp
 
 from zope.security import testing
+from zope.security.interfaces import PUBLIC_PERMISSION_NAME as zope_Public
 
 class TestTestingFunctions(CleanUp,
                            unittest.TestCase):
@@ -64,7 +65,7 @@ class TestTestingFunctions(CleanUp,
         from zope.security.interfaces import IPermission
 
         perm = testing.addCheckerPublic()
-        utility = component.getUtility(IPermission, name='zope.Public')
+        utility = component.getUtility(IPermission, name=zope_Public)
         self.assertIs(perm, utility)
 
 

--- a/src/zope/security/tests/test_zcml.py
+++ b/src/zope/security/tests/test_zcml.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 import unittest
-
+from zope.security.interfaces import PUBLIC_PERMISSION_NAME as zope_Public
 
 class ConformsToIFromUnicode(object):
 
@@ -56,7 +56,7 @@ class PermissionTests(unittest.TestCase,
     def test__validate_w_public(self):
         context = DummyZCMLContext()
         permission = self._makeOne(context)
-        permission._validate('zope.Public')
+        permission._validate(zope_Public)
         self.assertEqual(len(context._actions), 0)
 
     def test__validate_w_non_public(self):

--- a/src/zope/security/zcml.py
+++ b/src/zope/security/zcml.py
@@ -24,6 +24,7 @@ from zope.schema.interfaces import IFromUnicode
 
 from zope.security.permission import checkPermission
 from zope.security.management import setSecurityPolicy
+from zope.security.interfaces import PUBLIC_PERMISSION_NAME as zope_Public
 
 @implementer(IFromUnicode)
 class Permission(Id):
@@ -39,7 +40,7 @@ class Permission(Id):
     def _validate(self, value):
         super(Permission, self)._validate(value)
 
-        if value != 'zope.Public':
+        if value != zope_Public:
             self.context.action(
                 discriminator=None,
                 callable=checkPermission,


### PR DESCRIPTION
And use it consistently throughout this package.

On Python 2, sometimes we were comparing the string with unicode and sometimes with str. Now its consistent.

I didn't see anywhere that the extra LOAD_GLOBAL bytecode might be a performance issue.

This is a start to addressing #6