### PR TITLE
Fixes #10: Pure-python proxies don't check __unicode__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,13 @@
 4.2.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Make the pure-Python proxy on Python 2 *not* check permissions for
+  ``__unicode__`` just like the C implementation. Note that
+  ``__str__`` is checked for both implementations on both Python 2 and
+  3, but if there is no ``__unicode__`` method defined, Python 2's
+  automatic fallback to ``__str__`` is **not** checked when
+  ``unicode`` is called. See `issue 10
+  <https://github.com/zopefoundation/zope.security/issues/10>`_.
 
 
 4.2.1 (2017-11-30)

--- a/src/zope/security/proxy.py
+++ b/src/zope/security/proxy.py
@@ -282,7 +282,7 @@ class ProxyPy(PyProxyBase):
 for name in ['__call__',
              #'__repr__',
              #'__str__',
-             '__unicode__',
+             #'__unicode__', # Unchecked in C proxy
              '__reduce__',
              '__reduce_ex__',
              #'__lt__',      # Unchecked in C proxy (rich coparison)


### PR DESCRIPTION
Just like the C implementation. Note that ``__str__`` is checked for both implementations on both Python 2 and 3, but if there is no ``__unicode__`` method defined, Python 2's automatic fallback to
``__str__`` is **not** checked when ``unicode`` is called.

Add tests for these cases.