### PR TITLE
Add ``ISystemPrincipal`` and make ``system_user`` a regular object that implements it

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@
 4.2.4 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add the interface ``ISystemPrincipal`` and make
+  ``zope.security.management.system_user`` a regular object that
+  implements this interface. This facilitates providing adapter
+  registrations specifically for the ``system_user``.
 
 
 4.2.3 (2018-08-09)

--- a/src/zope/security/_definitions.py
+++ b/src/zope/security/_definitions.py
@@ -20,8 +20,10 @@ from zope.security import interfaces
 
 thread_local = threading.local()
 
-@zope.interface.provider(interfaces.IPrincipal)
-class system_user(object):
+@zope.interface.implementer(interfaces.ISystemPrincipal)
+class SystemUser(object):
     id = u'zope.security.management.system_user'
     title = u'System'
     description = u''
+
+system_user = SystemUser()

--- a/src/zope/security/interfaces.py
+++ b/src/zope/security/interfaces.py
@@ -38,6 +38,7 @@ These can be categorized into a few different groups of related objects.
   - :class:`IParticipation`
   - :class:`IInteractionManagement`
   - :class:`IPrincipal`
+  - :class:`ISystemPrincipal`
   - :class:`IGroupAwarePrincipal`
   - :class:`IGroupClosureAwarePrincipal`
   - :class:`IGroup`
@@ -392,6 +393,20 @@ class IPrincipal(Interface):
         title=_("Description"),
         description=_("A detailed description of the principal."),
         required=False)
+
+
+class ISystemPrincipal(IPrincipal):
+    """
+    A principal that represents the system (application) itself.
+
+    Typically a system principal is granted extra capabilities
+    or excluded from certain checks. End users should *not* be able
+    to act as the system principal.
+
+    Because speed is often a factor, a single instance of a system principal
+    is found at ``zope.security.management.system_user`` and can
+    be compared for by identity (e.g., ``if principal is system_user:``).
+    """
 
 
 class IGroupAwarePrincipal(IPrincipal):

--- a/src/zope/security/management.py
+++ b/src/zope/security/management.py
@@ -26,8 +26,21 @@ from zope.security.interfaces import ISecurityManagement
 from zope.security.interfaces import NoInteraction
 from zope.security.simplepolicies import ParanoidSecurityPolicy
 from zope.security._definitions import thread_local
-from zope.security._definitions import system_user # API?
+from zope.security._definitions import system_user
 
+
+__all__ = [
+    'system_user',
+    'getSecurityPolicy',
+    'setSecurityPolicy',
+    'queryInteraction',
+    'getInteraction',
+    'ExistingInteraction',
+    'newInteraction',
+    'endInteraction',
+    'restoreInteraction',
+    'checkPermission',
+]
 
 _defaultPolicy = ParanoidSecurityPolicy
 

--- a/src/zope/security/tests/test_management.py
+++ b/src/zope/security/tests/test_management.py
@@ -170,7 +170,11 @@ class Test(unittest.TestCase):
         self.assertEqual(checkPermission(None, obj), True)
         self.assertEqual(checkPermission(CheckerPublic, obj), True)
 
+
     def test_system_user(self):
+        from zope.interface.verify import verifyObject
+        from zope.security.interfaces import IPrincipal
+        from zope.security.interfaces import ISystemPrincipal
         from zope.security.management import system_user
 
         self.assertEqual(system_user.id,
@@ -181,6 +185,10 @@ class Test(unittest.TestCase):
         for name in 'id', 'title', 'description':
             self.assertIsInstance(getattr(system_user, name),
                                   type(u''))
+
+        verifyObject(IPrincipal, system_user)
+        verifyObject(ISystemPrincipal, system_user)
+
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
This facilitates adding adapter registrations for the system user.

Previously, `system_user` was just the class object, and it directly (and only) provided `IPrincipal`. This led to some ugly hacks in our code when we needed to (generically) handle the `system_user` (specifically, we were adding methods and `directlyProvides` to the `system_user` type instead of being able to register adapters like normal).

``system_user`` was exported from `zope.security.management` with the comment `# API?`. This makes it official.