### PR TITLE
Properly declare dependency on zope.schema >= 4.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@
 
 - Add support for Python 3.8a3.
 
+- Properly declare dependency on zope.schema >= 4.2.0, introduced in
+  zope.security 4.2.1.
+
 
 4.3.1 (2019-01-03)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ setup(name='zope.security',
           'zope.interface',
           'zope.location',
           'zope.proxy >= 4.3.0',
-          'zope.schema',
+          'zope.schema >= 4.2.0',
       ],
       tests_require=TESTS_REQUIRE,
       extras_require={


### PR DESCRIPTION
This was introduced in zope.security 4.2.1.