### PR TITLE
Let interfaces be iterated on Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,14 +2,16 @@
  Changes
 =========
 
-5.1 (unreleased)
-================
+5.1.0 (unreleased)
+==================
 
-- Nothing changed yet.
+- Let proxied interfaces be iterated on Python 3. This worked on
+  Python 2, but raised ``ForbiddenAttribute`` an Python 3. See
+  `zope.interface issue 141 <https://github.com/zopefoundation/zope.interface/issues/141>`_.
 
 
-5.0 (2019-11-11)
-================
+5.0.0 (2019-11-11)
+==================
 
 - Drop support for Python 3.4.
 

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ TESTS_REQUIRE = [
 
 
 setup(name='zope.security',
-      version='5.1.dev0',
+      version='5.1.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description='Zope Security Framework',

--- a/src/zope/security/checker.py
+++ b/src/zope/security/checker.py
@@ -858,8 +858,14 @@ _default_checkers = {
     type(f()): _iteratorChecker,
     type(Interface): InterfaceChecker(
         IInterface,
-        __str__=CheckerPublic, _implied=CheckerPublic, subscribe=CheckerPublic,
-        ),
+        __str__=CheckerPublic,
+        _implied=CheckerPublic,
+        subscribe=CheckerPublic,
+        # To iterate, Python calls __len__ as a hint.
+        # Python 2 ignores AttributeErrors, but Python 3
+        # lets them pass.
+        __len__=CheckerPublic,
+    ),
     zope.interface.interface.Method: InterfaceChecker(
         zope.interface.interfaces.IMethod),
     zope.interface.declarations.ProvidesClass: _Declaration_checker,


### PR DESCRIPTION
Fixes https://github.com/zopefoundation/zope.interface/issues/141