### PR TITLE
Fix default checker for method-wrapper on Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@
 5.3 (unreleased)
 ================
 
-- Nothing changed yet.
+- Allow calling bound methods of some built-in objects such as ``().__repr__``
+  and ``{}.__repr__`` by default. This worked on Python 2, but raised
+  ``ForbiddenAttribute`` on Python 3. See `issue 75
+  <https://github.com/zopefoundation/zope.security/issues/75>`_.
 
 
 5.2 (2022-03-10)

--- a/src/zope/security/checker.py
+++ b/src/zope/security/checker.py
@@ -882,6 +882,8 @@ _default_checkers = {
     types.MethodType: _callableChecker,
     types.BuiltinFunctionType: _callableChecker,
     types.BuiltinMethodType: _callableChecker,
+    # method-wrapper
+    type(().__repr__): _callableChecker,
     type: _typeChecker,
     types.ModuleType: lambda module: _checkers.get(module, _namedChecker),
     type(iter([])): _iteratorChecker,  # Same types in Python 2.2.1,
@@ -912,7 +914,6 @@ if PYTHON2:  # pragma: no cover
     _default_checkers[types.ClassType] = _typeChecker
     _default_checkers[types.InstanceType] = _instanceChecker
     # slot description
-    _default_checkers[type(().__getslice__)] = _callableChecker
     _default_checkers[type({}.iteritems())] = _iteratorChecker
     _default_checkers[type({}.iterkeys())] = _iteratorChecker
     _default_checkers[type({}.itervalues())] = _iteratorChecker

--- a/src/zope/security/tests/test_proxy.py
+++ b/src/zope/security/tests/test_proxy.py
@@ -2171,6 +2171,11 @@ class ProxyFactoryTests(unittest.TestCase):
         self.assertEqual(list(IFoo), ['x'])
         self.assertEqual(list(proxy), list(IFoo))
 
+    def test_method_wrapper(self):
+        from zope.security.proxy import ProxyFactory
+
+        self.assertEqual(ProxyFactory({}).__repr__(), '{}')
+
 
 def test_using_mapping_slots_hack():
     """The security proxy will use mapping slots, on the checker to go faster


### PR DESCRIPTION
The default checker for `method-wrapper` objects such as `().__repr__`
and `{}.__repr__` was previously set by setting the default checker
`type(().__getslice__)`, which only worked on Python 2.  Use a different
exemplar for this type which works on both Python 2 and 3.

Fixes #75.