### PR TITLE
re #83: Remove `unittest.makeSuite` as it is deprecated in Python 3.11+.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@
   ``ForbiddenAttribute`` on Python 3. See `issue 75
   <https://github.com/zopefoundation/zope.security/issues/75>`_.
 
+- Remove usage of ``unittest.makeSuite`` as it is deprecated in Python 3.11+.
+  See `issue 83
+  <https://github.com/zopefoundation/zope.security/issues/83>`_.
+
 
 5.2 (2022-03-10)
 ================

--- a/src/zope/security/tests/test_protectclass.py
+++ b/src/zope/security/tests/test_protectclass.py
@@ -141,7 +141,7 @@ class Bar(Foo):
 
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite(Test_protectName),
-        unittest.makeSuite(Test_protectSetAttribute),
-        unittest.makeSuite(Test_protectLikeUnto),
+        unittest.defaultTestLoader.loadTestsFromTestCase(Test_protectName),
+        unittest.defaultTestLoader.loadTestsFromTestCase(Test_protectSetAttribute),
+        unittest.defaultTestLoader.loadTestsFromTestCase(Test_protectLikeUnto),
     ))

--- a/src/zope/security/tests/test_simpleinteraction.py
+++ b/src/zope/security/tests/test_simpleinteraction.py
@@ -76,5 +76,5 @@ class TestInteraction(unittest.TestCase):
 
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite(TestInteraction),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestInteraction),
     ))

--- a/src/zope/security/tests/test_zcml.py
+++ b/src/zope/security/tests/test_zcml.py
@@ -193,8 +193,8 @@ class DummyZCMLContext(object):
 
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite(PermissionTests),
-        unittest.makeSuite(Test_securityPolicy),
-        unittest.makeSuite(Test_permission),
-        unittest.makeSuite(Test_redefinePermission),
+        unittest.defaultTestLoader.loadTestsFromTestCase(PermissionTests),
+        unittest.defaultTestLoader.loadTestsFromTestCase(Test_securityPolicy),
+        unittest.defaultTestLoader.loadTestsFromTestCase(Test_permission),
+        unittest.defaultTestLoader.loadTestsFromTestCase(Test_redefinePermission),
     ))


### PR DESCRIPTION
Fixes #83 .