### PR TITLE
Update to Python 3.11b1 + fix doc creation.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-alpha.7"
+          - "3.11.0-beta.1"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -173,7 +173,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.11.0-alpha.7')
+          && !startsWith(matrix.python-version, '3.11.0-beta.1')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -195,7 +195,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-alpha.7"
+          - "3.11.0-beta.1"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "dbaca5f3c7785b7bca563dabc5f440544069a8f9"
+commit-id = "5f8f4eb428494f5cc349f91f7c312095e7ad7422"
 
 [python]
 with-appveyor = true
@@ -20,7 +20,7 @@ additional-envlist = [
     ]
 testenv-setenv = [
     "ZOPE_INTERFACE_STRICT_IRO=1",
-    "watch: ZOPE_WATCH_CHECKERS = 1",
+    "watch: ZOPE_WATCH_CHECKERS=1",
     ]
 
 [coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -22,11 +22,13 @@ envlist =
 usedevelop = true
 pip_pre = true
 deps =
+  # repoze.sphinx.autointerface does not yet support Sphinx >= 5:
+  Sphinx < 5
 setenv =
     pure: PURE_PYTHON=1
     !pure-!pypy-!pypy3: PURE_PYTHON=0
     ZOPE_INTERFACE_STRICT_IRO=1
-    watch: ZOPE_WATCH_CHECKERS = 1
+    watch: ZOPE_WATCH_CHECKERS=1
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
     !py27-!pypy: sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest


### PR DESCRIPTION
Until `repoze.sphinx.autointerface` supports Sphinx 5 (which is used here because we support future python versions and activate installing pre-released package version, which is needed for some other packages to get a RestrictedPython which runs on Python 3.11) we have to use an older version.

Uses https://github.com/zopefoundation/meta/pull/147