### PR TITLE
Fix GHA Python 3.10 build on MacOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,7 +146,6 @@ jobs:
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine "cffi != 1.15.1"
-
       - name: Install Build Dependencies (other Python versions)
         if: >
           !startsWith(matrix.python-version, 'pypy-2.7')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,9 +136,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}
+          key: ${{ runner.os }}-pip-2-${{ matrix.python-version }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-pip-2-
 
       - name: Install Build Dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Install Build Dependencies
         run: |
           pip install -U pip
-          pip install -U wheel twine cffi "setuptools < 62.4"
+          pip install -U wheel twine cffi "setuptools < 62.4" "certifi < 2022.6.15"
 
       - name: Build zope.security
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,14 +136,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-2-${{ matrix.python-version }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}
           restore-keys: |
-            ${{ runner.os }}-pip-2-
+            ${{ runner.os }}-pip-
 
       - name: Install Build Dependencies
         run: |
           pip install -U pip
-          pip install -U wheel twine cffi "setuptools < 62.4" "certifi < 2022.6.15"
+          pip install -U setuptools wheel twine cffi
 
       - name: Build zope.security
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Install Build Dependencies (other Python versions)
         if: >
-          startsWith(matrix.python-version, 'pypy-2.7')
+          !startsWith(matrix.python-version, 'pypy-2.7')
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,11 +140,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Install Build Dependencies
+      - name: Install Build Dependencies (PyPy2)
+        if: >
+          startsWith(matrix.python-version, 'pypy-2.7')
         run: |
-          pip install -U setuptools
           pip install -U pip
-          pip install -U wheel twine cffi
+          pip install -U setuptools wheel twine "cffi != 1.15.1"
+
+      - name: Install Build Dependencies (other Python versions)
+        if: >
+          startsWith(matrix.python-version, 'pypy-2.7')
+        run: |
+          pip install -U pip
+          pip install -U setuptools wheel twine cffi
 
       - name: Build zope.security (Python 3.10 on MacOS)
         if: >

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10.4"
+          - "3.10"
           - "3.11.0-beta.1"
         os: [ubuntu-20.04, macos-latest]
         exclude:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,9 +145,25 @@ jobs:
           pip install -U pip
           pip install -U setuptools wheel twine cffi
 
-      - name: Build zope.security
+      - name: Build zope.security (Python 3.10 on MacOS)
+        if: >
+          startsWith(runner.os, 'Mac')
+          && startsWith(matrix.python-version, '3.10')
         env:
           _PYTHON_HOST_PLATFORM: macosx-11-x86_64
+        run: |
+          # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
+          # output (pip install uses a random temporary directory, making this difficult).
+          python setup.py build_ext -i
+          python setup.py bdist_wheel
+          # Also install it, so that we get dependencies in the (pip) cache.
+          pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
+          pip install --pre .[test]
+
+      - name: Build zope.security (all other versions)
+        if: >
+          !startsWith(runner.os, 'Mac')
+          || !startsWith(matrix.python-version, '3.10')
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
           # output (pip install uses a random temporary directory, making this difficult).
@@ -321,7 +337,7 @@ jobs:
         run: |
           pip install -U wheel
           pip install -U coverage
-          pip install -U  "`ls dist/zope.security-${{ runner.os }}-${{ matrix.python-version }}.whl`[docs]"
+          pip install -U  "`ls dist/zope.security-*.whl`[docs]"
       - name: Build docs
         env:
           ZOPE_INTERFACE_STRICT_IRO: 1
@@ -372,7 +388,7 @@ jobs:
         run: |
           pip install -U pip
           pip install -U wheel
-          pip install -U `ls dist/zope.security-${{ runner.os }}-${{ matrix.python-version }}`[test]
+          pip install -U `ls dist/zope.security-*`[test]
       - name: Lint
         # We only need to do this on one version, and it should be Python 3, because
         # pylint has stopped updating for Python 2.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,8 +149,10 @@ jobs:
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
           # output (pip install uses a random temporary directory, making this difficult).
-          rm -rf /Users/runner/work/zope.security/zope.security/.eggs
+          echo ">>> python setup.py build_ext -i"
           python setup.py build_ext -i
+          echo ">>> rm -rf /Users/runner/work/zope.security/zope.security/.eggs"
+          rm -rf /Users/runner/work/zope.security/zope.security/.eggs
           python setup.py bdist_wheel
           # Also install it, so that we get dependencies in the (pip) cache.
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,8 +142,9 @@ jobs:
 
       - name: Install Build Dependencies
         run: |
+          pip install -U setuptools
           pip install -U pip
-          pip install -U setuptools wheel twine cffi
+          pip install -U wheel twine cffi
 
       - name: Build zope.security (Python 3.10 on MacOS)
         if: >

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-beta.1"
+          - "3.11.0-beta.3"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -191,7 +191,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.11.0-beta.1')
+          && !startsWith(matrix.python-version, '3.11.0-beta.3')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -213,7 +213,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-beta.1"
+          - "3.11.0-beta.3"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Install Build Dependencies
         run: |
           pip install -U pip
-          pip install -U "setuptools < 62.4" wheel twine cffi
+          pip install -U wheel twine cffi "setuptools < 62.4"
 
       - name: Build zope.security
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,13 +150,11 @@ jobs:
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
           # output (pip install uses a random temporary directory, making this difficult).
           echo ">>> python setup.py build_ext -i"
-          python setup.py build_ext -i
-          echo ">>> rm -rf /Users/runner/work/zope.security/zope.security/.eggs"
-          rm -rf /Users/runner/work/zope.security/zope.security/.eggs
-          python setup.py bdist_wheel
+          _PYTHON_HOST_PLATFORM="macosx-11-x86_64" python setup.py build_ext -i
+          _PYTHON_HOST_PLATFORM="macosx-11-x86_64" python setup.py bdist_wheel
           # Also install it, so that we get dependencies in the (pip) cache.
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
-          pip install --pre .[test]
+          _PYTHON_HOST_PLATFORM="macosx-11-x86_64" pip install --pre .[test]
 
       - name: Check zope.security build
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,6 +149,7 @@ jobs:
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
           # output (pip install uses a random temporary directory, making this difficult).
+          rm -rf /Users/runner/work/zope.security/zope.security/.eggs
           python setup.py build_ext -i
           python setup.py bdist_wheel
           # Also install it, so that we get dependencies in the (pip) cache.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Install Build Dependencies
         run: |
           pip install -U pip
-          pip install -U setuptools wheel twine cffi
+          pip install -U "setuptools < 62.4" wheel twine cffi
 
       - name: Build zope.security
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -321,7 +321,7 @@ jobs:
         run: |
           pip install -U wheel
           pip install -U coverage
-          pip install -U  "`ls dist/zope.security-*.whl`[docs]"
+          pip install -U  "`ls dist/zope.security-${{ runner.os }}-${{ matrix.python-version }}.whl`[docs]"
       - name: Build docs
         env:
           ZOPE_INTERFACE_STRICT_IRO: 1
@@ -372,7 +372,7 @@ jobs:
         run: |
           pip install -U pip
           pip install -U wheel
-          pip install -U `ls dist/zope.security-*`[test]
+          pip install -U `ls dist/zope.security-${{ runner.os }}-${{ matrix.python-version }}`[test]
       - name: Lint
         # We only need to do this on one version, and it should be Python 3, because
         # pylint has stopped updating for Python 2.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,15 +146,16 @@ jobs:
           pip install -U setuptools wheel twine cffi
 
       - name: Build zope.security
+        env:
+          _PYTHON_HOST_PLATFORM: macosx-11-x86_64
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
           # output (pip install uses a random temporary directory, making this difficult).
-          echo ">>> python setup.py build_ext -i"
-          _PYTHON_HOST_PLATFORM="macosx-11-x86_64" python setup.py build_ext -i
-          _PYTHON_HOST_PLATFORM="macosx-11-x86_64" python setup.py bdist_wheel
+          python setup.py build_ext -i
+          python setup.py bdist_wheel
           # Also install it, so that we get dependencies in the (pip) cache.
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
-          _PYTHON_HOST_PLATFORM="macosx-11-x86_64" pip install --pre .[test]
+          pip install --pre .[test]
 
       - name: Check zope.security build
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10"
+          - "3.10.4"
           - "3.11.0-beta.1"
         os: [ubuntu-20.04, macos-latest]
         exclude:

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -37,8 +37,8 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]] ; then
-        "${PYBIN}/pip" install -e /io/
-        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        "${PYBIN}/pip" install --pre -e /io/
+        "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
         if [ `uname -m` == 'aarch64' ]; then
           cd /io/
           "${PYBIN}/pip" install tox

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "4a77536ce8ad583884a6a3106429fc8af3e13224"
+commit-id = "9f8458e3f26368d43f9fae284fc063a97b2a651c"
 
 [python]
 with-appveyor = true

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "5f8f4eb428494f5cc349f91f7c312095e7ad7422"
+commit-id = "4a77536ce8ad583884a6a3106429fc8af3e13224"
 
 [python]
 with-appveyor = true

--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,8 @@ envlist =
 usedevelop = true
 pip_pre = true
 deps =
-  # repoze.sphinx.autointerface does not yet support Sphinx >= 5:
-  Sphinx < 5
+    # repoze.sphinx.autointerface does not yet support Sphinx >= 5:
+    Sphinx < 5
 setenv =
     pure: PURE_PYTHON=1
     !pure-!pypy-!pypy3: PURE_PYTHON=0


### PR DESCRIPTION
Using a setuptools version which worked up to last week.

Goal is to fix https://github.com/zopefoundation/zope.security/runs/6961463587?check_suite_focus=true

Locally the problem does not occur when running the tests using `tox`.