### PR TITLE
Remove more proxying code for names that no longer exist in Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
  Changes
 =========
 
+6.1 (unreleased)
+================
+
+- Remove more proxying code for names that no longer exist in Python 3.
+  (`#92 <https://github.com/zopefoundation/zope.security/issues/92>`_)
+
+
 6.0 (2023-01-16)
 ================
 

--- a/src/zope/security/_proxy.c
+++ b/src/zope/security/_proxy.c
@@ -55,7 +55,6 @@ DECLARE_STRING(__cmp__);
 DECLARE_STRING(__contains__);
 DECLARE_STRING(__delitem__);
 DECLARE_STRING(__getitem__);
-DECLARE_STRING(__getslice__);
 DECLARE_STRING(__hash__);
 DECLARE_STRING(__iter__);
 DECLARE_STRING(__len__);
@@ -107,7 +106,6 @@ DECLARE_STRING(proxy);
 DECLARE_STRING(__repr__);
 DECLARE_STRING(__rpow__);
 DECLARE_STRING(__setitem__);
-DECLARE_STRING(__setslice__);
 DECLARE_STRING(__str__);
 
 typedef struct {
@@ -639,25 +637,6 @@ proxy_isetitem(SecurityProxy *self, Py_ssize_t i, PyObject *value)
   return res;
 }
 
-static PyObject *
-proxy_slice(SecurityProxy *self, Py_ssize_t start, Py_ssize_t end)
-{
-  PyObject *result = NULL;
-
-  if (check(self, str_check, str___getslice__) >= 0) {
-    result = PySequence_GetSlice(self->proxy.proxy_object, start, end);
-    PROXY_RESULT(self, result);
-  }
-  return result;
-}
-
-static int
-proxy_ass_slice(SecurityProxy *self, Py_ssize_t i, Py_ssize_t j, PyObject *value)
-{
-  if (check(self, str_check, str___setslice__) >= 0)
-    return PySequence_SetSlice(self->proxy.proxy_object, i, j, value);
-  return -1;
-}
 
 static int
 proxy_contains(SecurityProxy *self, PyObject *value)
@@ -751,9 +730,9 @@ proxy_as_sequence = {
   0,                                        /* sq_concat */
   0,                                        /* sq_repeat */
   (ssizeargfunc)proxy_igetitem,             /* sq_item */
-  (ssizessizeargfunc)proxy_slice,           /* sq_slice */
+  0,                                        /* sq_slice, unused in PY3 */
   (ssizeobjargproc)proxy_isetitem,          /* sq_ass_item */
-  (ssizessizeobjargproc)proxy_ass_slice,    /* sq_ass_slice */
+  0,                                        /* sq_ass_slice, unused in PY3 */
   (objobjproc)proxy_contains,               /* sq_contains */
 };
 
@@ -896,7 +875,6 @@ if((str_op_##S = INTERN("__" #S "__")) == NULL) return MOD_ERROR_VAL
   INIT_STRING(__contains__);
   INIT_STRING(__delitem__);
   INIT_STRING(__getitem__);
-  INIT_STRING(__getslice__);
   INIT_STRING(__hash__);
   INIT_STRING(__iter__);
   INIT_STRING(__len__);
@@ -948,7 +926,6 @@ if((str_op_##S = INTERN("__" #S "__")) == NULL) return MOD_ERROR_VAL
   INIT_STRING(__repr__);
   INIT_STRING(__rpow__);
   INIT_STRING(__setitem__);
-  INIT_STRING(__setslice__);
   INIT_STRING(__str__);
 
 

--- a/src/zope/security/checker.py
+++ b/src/zope/security/checker.py
@@ -719,7 +719,7 @@ def moduleChecker(module):
 _available_by_default[:] = [
     '__lt__', '__le__', '__eq__',
     '__gt__', '__ge__', '__ne__',
-    '__hash__', '__nonzero__',
+    '__hash__', '__bool__',
     '__class__', '__providedBy__', '__implements__',
     '__repr__', '__conform__',
     '__name__', '__parent__',
@@ -843,14 +843,14 @@ _default_checkers = {
                         'get', 'has_key', 'copy', '__str__', 'keys',
                         'values', 'items', 'iterkeys', 'iteritems',
                         'itervalues', '__contains__']),
-    list: NamesChecker(['__getitem__', '__getslice__', '__len__', '__iter__',
+    list: NamesChecker(['__getitem__', '__len__', '__iter__',
                         '__contains__', 'index', 'count', '__str__',
                         '__add__', '__radd__', ]),
     set: _setChecker,
     frozenset: _setChecker,
     # XXX: actually decimal.Decimal has more methods, which are unlisted here
     #      so expect ForbiddenAttribute on such
-    decimal.Decimal: NamesChecker(['__nonzero__', '__cmp__', '__eq__',
+    decimal.Decimal: NamesChecker(['__bool__', '__cmp__', '__eq__',
                                    '__ne__', '__hash__',
                                    '__str__',
                                    '__neg__', '__pos__', '__abs__',
@@ -870,7 +870,7 @@ _default_checkers = {
                                    'to_eng_string', 'to_integral']),
 
     # YAGNI: () a rock
-    tuple: NamesChecker(['__getitem__', '__getslice__', '__add__', '__radd__',
+    tuple: NamesChecker(['__getitem__', '__add__', '__radd__',
                          '__contains__', '__len__', '__iter__',
                          '__str__']),
     Proxy: NoProxy,

--- a/src/zope/security/proxy.py
+++ b/src/zope/security/proxy.py
@@ -103,7 +103,7 @@ class ProxyPy(PyProxyBase):
         checker = super().__getattribute__('_checker')
         if name == '_checker':
             return checker
-        if name not in ('__cmp__', '__hash__', '__bool__', '__nonzero__',
+        if name not in ('__cmp__', '__hash__', '__bool__',
                         '__lt__', '__le__', '__eq__', '__ne__', '__ge__',
                         '__gt__'):
             checker.check_getattr(wrapped, name)
@@ -209,11 +209,10 @@ class ProxyPy(PyProxyBase):
         wrapped = super().__getattribute__('_wrapped')
         return hash(wrapped)
 
-    def __nonzero__(self):
+    def __bool__(self):
         # no check
         wrapped = super().__getattribute__('_wrapped')
         return bool(wrapped)
-    __bool__ = __nonzero__
 
     def __length_hint__(self):
         # no check
@@ -267,7 +266,6 @@ for name in ['__call__',
              # '__ne__',      # Unchecked in C proxy (rich comparison)
              # '__ge__',      # Unchecked in C proxy (rich comparison)
              # '__gt__',      # Unchecked in C proxy (rich comparison)
-             # '__nonzero__', # Unchecked in C proxy (rich comparison)
              # '__bool__',    # Unchecked in C proxy (rich comparison)
              # '__hash__',    # Unchecked in C proxy (rich comparison)
              # '__cmp__',     # Unchecked in C proxy

--- a/src/zope/security/tests/test_checker.py
+++ b/src/zope/security/tests/test_checker.py
@@ -1985,7 +1985,7 @@ class TestSecurityPolicy(QuietWatchingChecker,
         class C:
             pass
         self.assertEqual(checker.check(C, '__hash__'), None)
-        self.assertEqual(checker.check(C, '__nonzero__'), None)
+        self.assertEqual(checker.check(C, '__bool__'), None)
         self.assertEqual(checker.check(C, '__class__'), None)
         self.assertEqual(checker.check(C, '__implements__'), None)
         self.assertEqual(checker.check(C, '__lt__'), None)


### PR DESCRIPTION
See #92 

- Fix up remaining instances of `__nonzero__`, which is renamed to `__bool__`
- `__getslice__` and `__setslice__` are unused in Python 3, replaced by `__getitem__` and `__setitem__` with slice objects passed in.