### PR TITLE
Add preliminary support for Python 3.12b2.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12.0-alpha.7"
+          - "3.12.0-beta.1"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
@@ -179,15 +179,15 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
 
-      - name: Install zope.security and dependencies (3.12.0-alpha.7)
-        if: matrix.python-version == '3.12.0-alpha.7'
+      - name: Install zope.security and dependencies (3.12.0-beta.1)
+        if: matrix.python-version == '3.12.0-beta.1'
         run: |
           # Install to collect dependencies into the (pip) cache.
           # Use "--pre" here because dependencies with support for this future
           # Python release may only be available as pre-releases
           pip install --pre .[test]
       - name: Install zope.security and dependencies
-        if: matrix.python-version != '3.12.0-alpha.7'
+        if: matrix.python-version != '3.12.0-beta.1'
         run: |
           # Install to collect dependencies into the (pip) cache.
           pip install .[test]
@@ -231,7 +231,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.12.0-alpha.7')
+          && !startsWith(matrix.python-version, '3.12.0-beta.1')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -250,7 +250,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12.0-alpha.7"
+          - "3.12.0-beta.1"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
@@ -287,8 +287,8 @@ jobs:
         with:
           name: zope.security-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
-      - name: Install zope.security 3.12.0-alpha.7
-        if: ${{ startsWith(matrix.python-version, '3.12.0-alpha.7') }}
+      - name: Install zope.security 3.12.0-beta.1
+        if: ${{ startsWith(matrix.python-version, '3.12.0-beta.1') }}
         run: |
           pip install -U wheel setuptools
           # coverage has a wheel on PyPI for a future python version which is
@@ -302,7 +302,7 @@ jobs:
           # Python release may only be available as pre-releases
           pip install --pre -U -e .[test]
       - name: Install zope.security
-        if: ${{ !startsWith(matrix.python-version, '3.12.0-alpha.7') }}
+        if: ${{ !startsWith(matrix.python-version, '3.12.0-beta.1') }}
         run: |
           pip install -U wheel setuptools
           pip install -U coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12.0-beta.1"
+          - "3.12.0-beta.2"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
@@ -179,15 +179,15 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
 
-      - name: Install zope.security and dependencies (3.12.0-beta.1)
-        if: matrix.python-version == '3.12.0-beta.1'
+      - name: Install zope.security and dependencies (3.12.0-beta.2)
+        if: matrix.python-version == '3.12.0-beta.2'
         run: |
           # Install to collect dependencies into the (pip) cache.
           # Use "--pre" here because dependencies with support for this future
           # Python release may only be available as pre-releases
           pip install --pre .[test]
       - name: Install zope.security and dependencies
-        if: matrix.python-version != '3.12.0-beta.1'
+        if: matrix.python-version != '3.12.0-beta.2'
         run: |
           # Install to collect dependencies into the (pip) cache.
           pip install .[test]
@@ -231,7 +231,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.12.0-beta.1')
+          && !startsWith(matrix.python-version, '3.12.0-beta.2')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -250,7 +250,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12.0-beta.1"
+          - "3.12.0-beta.2"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
@@ -287,8 +287,8 @@ jobs:
         with:
           name: zope.security-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
-      - name: Install zope.security 3.12.0-beta.1
-        if: ${{ startsWith(matrix.python-version, '3.12.0-beta.1') }}
+      - name: Install zope.security 3.12.0-beta.2
+        if: ${{ startsWith(matrix.python-version, '3.12.0-beta.2') }}
         run: |
           pip install -U wheel setuptools
           # coverage has a wheel on PyPI for a future python version which is
@@ -302,7 +302,7 @@ jobs:
           # Python release may only be available as pre-releases
           pip install --pre -U -e .[test]
       - name: Install zope.security
-        if: ${{ !startsWith(matrix.python-version, '3.12.0-beta.1') }}
+        if: ${{ !startsWith(matrix.python-version, '3.12.0-beta.2') }}
         run: |
           pip install -U wheel setuptools
           pip install -U coverage

--- a/.meta.toml
+++ b/.meta.toml
@@ -36,7 +36,12 @@ additional-rules = [
 
 [check-manifest]
 additional-ignores = [
-    "docs/_build/html/_sources/api/*",
+    "docs/_build/*/*/*/*/*",
+    "docs/_build/*/*/*/*",
+    "docs/_build/*/*/*",
+    "docs/_build/*/*",
+    "docs/_build/*",
+    "src/coverage.xml",
     ]
 
 [flake8]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@
 
 - Drop using ``setup_requires`` due to constant problems on GHA.
 
-- Add preliminary support for Python 3.12 as of 3.12a7 -- even though there are
+- Add preliminary support for Python 3.12 as of 3.12b1 -- even though there are
   currently tests breaking, so please do not consider it fully supported.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@
 
 - Drop using ``setup_requires`` due to constant problems on GHA.
 
-- Add preliminary support for Python 3.12 as of 3.12b1 -- even though there are
+- Add preliminary support for Python 3.12 as of 3.12b2 -- even though there are
   currently tests breaking, so please do not consider it fully supported.
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,12 @@ ignore =
     .meta.toml
     docs/_build/html/_sources/*
     docs/_build/doctest/*
-    docs/_build/html/_sources/api/*
+    docs/_build/*/*/*/*/*
+    docs/_build/*/*/*/*
+    docs/_build/*/*/*
+    docs/_build/*/*
+    docs/_build/*
+    src/coverage.xml
 
 [isort]
 force_single_line = True


### PR DESCRIPTION
Let's see if 3.12b1 also fails the tests.
Locally they are fine.