### PR TITLE
Allow calling builtin_method objects by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@
 7.1 (unreleased)
 ----------------
 
+- Allow calling methods of type ``<class 'builtin_method'>`` by default. In
+  particular, Python 3.12 refactored the ``io`` module in such a way as to
+  slightly change the types of some methods, causing ``zope.security`` to no
+  longer consider them callable. See `zope.file issue #13
+  <https://github.com/zopefoundation/zope.file/issues/13>`.
+
 
 7.0 (2024-05-30)
 ----------------

--- a/src/zope/security/checker.py
+++ b/src/zope/security/checker.py
@@ -60,6 +60,7 @@ API
 import abc
 import datetime
 import decimal
+import io
 import os
 import sys
 import types
@@ -879,6 +880,14 @@ _default_checkers = {
     types.MethodType: _callableChecker,
     types.BuiltinFunctionType: _callableChecker,
     types.BuiltinMethodType: _callableChecker,
+    # At least on Python 3.5-3.12, types.BuiltinFunctionType and
+    # types.BuiltinMethodType are both <class 'builtin_function_or_method'>,
+    # or PyCFunctionType.  However, some builtin methods are <class
+    # 'builtin_method'> instead, or PyCMethodType, which is a subclass of
+    # PyCFunctionType but not identical to it.  As of Python 3.12, the io
+    # module makes more use of PyCMethodType, so we can use it to identify
+    # that type.
+    type(io.BytesIO().getbuffer): _callableChecker,
     # method-wrapper
     type(().__repr__): _callableChecker,
     type: _typeChecker,

--- a/src/zope/security/tests/test_proxy.py
+++ b/src/zope/security/tests/test_proxy.py
@@ -13,6 +13,8 @@
 ##############################################################################
 """Security proxy tests
 """
+import io
+import os
 import unittest
 
 from zope.security._compat import PURE_PYTHON
@@ -1814,6 +1816,11 @@ class ProxyFactoryTests(unittest.TestCase):
         from zope.security.proxy import ProxyFactory
 
         self.assertEqual(ProxyFactory({}).__repr__(), '{}')
+
+    def test_builtin_method(self):
+        from zope.security.proxy import ProxyFactory
+
+        self.assertEqual(ProxyFactory(io.FileIO(os.devnull, 'rb').read)(), b'')
 
 
 def test_using_mapping_slots_hack():


### PR DESCRIPTION
The type of these objects is a subclass of `types.BuiltinMethodType`, but not identical to it.  This caused downstream failures on Python >= 3.12 due to refactoring of the `io` module, such as
https://github.com/zopefoundation/zope.file/issues/13.