### PR TITLE
Respect `PURE_PYTHON` environment variable set to `0`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 7.3 (unreleased)
 ----------------
 
+- Respect ``PURE_PYTHON`` environment variable set to ``0``.
+
 
 7.2 (2024-09-17)
 ----------------

--- a/src/zope/security/_compat.py
+++ b/src/zope/security/_compat.py
@@ -19,7 +19,7 @@ import platform
 
 py_impl = getattr(platform, 'python_implementation', lambda: None)
 PYPY = py_impl() == 'PyPy'
-PURE_PYTHON = os.environ.get('PURE_PYTHON', PYPY)
+PURE_PYTHON = int(os.environ.get('PURE_PYTHON', PYPY))
 
 
 class implementer_if_needed:

--- a/src/zope/security/checker.py
+++ b/src/zope/security/checker.py
@@ -24,10 +24,10 @@ It also defines helpers for permission checking (:func:`canAccess`,
 (:func:`getCheckerForInstancesOf`, :func:`selectChecker`).
 
 This module is accelerated with a C implementation on CPython by
-default. If the environment variable ``PURE_PYTHON`` is set (to any
-value) before this module is imported, the C extensions will be
-bypassed and the reference Python implementations will be used. This
-can be helpful for debugging and tracing.
+default. If the environment variable ``PURE_PYTHON`` is set to ``1``
+before this module is imported, the C extensions will be bypassed and
+the reference Python implementations will be used. This can be helpful for
+debugging and tracing.
 
 Debugging Permissions Problems
 ==============================


### PR DESCRIPTION
Setting to 0 should be equivalent to not setting the variable.

Refs https://github.com/zopefoundation/meta/issues/283