### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-7.4 (unreleased)
+8.0 (unreleased)
 ----------------
 
 - Drop support for Python 3.8.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 8.0 (unreleased)
 ----------------
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Drop support for Python 3.8.
 
 - Add preliminary support for Python 3.14.

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from setuptools import setup
 from setuptools.command.build_ext import build_ext
 
 
-version = '7.4.dev0'
+version = '8.0.dev0'
 
 
 class optional_build_ext(build_ext):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ from distutils.errors import DistutilsExecError
 from distutils.errors import DistutilsPlatformError
 
 from setuptools import Extension
-from setuptools import find_packages
 from setuptools import setup
 from setuptools.command.build_ext import build_ext
 
@@ -102,7 +101,7 @@ TESTS_REQUIRE = [
     'zope.configuration',
     'zope.location',
     'zope.testing',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
 ]
 
 
@@ -144,9 +143,6 @@ setup(name='zope.security',
           'Sources': 'https://github.com/zopefoundation/zope.security',
       },
       license='ZPL-2.1',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope'],
       cmdclass={
           'build_ext': optional_build_ext,
       },

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
