### PR TITLE
Fix extension build failure with C23

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 8.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix ``zope.security._zope_security_checker`` extension build failure with
+  C23.
 
 
 8.0 (2025-09-15)

--- a/src/zope/security/_zope_security_checker.c
+++ b/src/zope/security/_zope_security_checker.c
@@ -14,7 +14,7 @@
 #include <Python.h>
 
 static PyObject *_checkers, *_defaultChecker, *_available_by_default, *NoProxy;
-static PyObject *Proxy, *thread_local, *CheckerPublic;
+static PyObject *Proxy, *_thread_local, *CheckerPublic;
 static PyObject *ForbiddenAttribute, *Unauthorized;
 
 
@@ -105,7 +105,7 @@ checkPermission(PyObject *permission, PyObject *object, PyObject *name)
 
 /*          if thread_local.interaction.checkPermission(permission, object): */
 /*                 return */
-      interaction = PyObject_GetAttr(thread_local, str_interaction);
+      interaction = PyObject_GetAttr(_thread_local, str_interaction);
       if (interaction == NULL)
         return -1;
       r = PyObject_CallMethodObjArgs(interaction, str_checkPermission,
@@ -620,8 +620,8 @@ if((str_##S = INTERN(#S)) == NULL) return MOD_ERROR_VAL
   {
     return MOD_ERROR_VAL;
   }
-  thread_local = PyObject_GetAttrString(m, "thread_local");
-  if (thread_local == NULL)
+  _thread_local = PyObject_GetAttrString(m, "thread_local");
+  if (_thread_local == NULL)
   {
     return MOD_ERROR_VAL;
   }


### PR DESCRIPTION
`thread_local` is a new keyword in C23.  Avoid colliding with it.

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [N/A] If needed, I added new tests for my changes.
- [N/A] If needed, I added documentation for my changes.
- [x] I included a change log entry in my commits.