### PR TITLE
Remove run-time dependency on setuptools

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 8.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Remove run-time dependency on ``setuptools``.
 
 
 8.0 (2025-09-15)

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,6 @@ setup(name='zope.security',
       ext_modules=ext_modules,
       python_requires='>=3.9',
       install_requires=[
-          'setuptools',
           'zope.component',
           'zope.i18nmessageid',
           'zope.interface',


### PR DESCRIPTION
It was needed for `pkg_resources`-style namespace packages, but that's no longer a problem here.

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [N/A] If needed, I added new tests for my changes.
- [N/A] If needed, I added documentation for my changes.
- [x] I included a change log entry in my commits.